### PR TITLE
[BB-1398] Conditionally define MAIL_* settings if present in environment

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -32,9 +32,19 @@ GITHUB_ACCESS_TOKEN = os.environ['GITHUB_ACCESS_TOKEN']
 
 WATCH_CONFIG = get_watch_config()
 
-MAIL_DEFAULT_SENDER = os.environ.get('MAIL_DEFAULT_SENDER')
-MAIL_SERVER = os.environ.get('MAIL_SERVER')
-MAIL_PORT = os.environ.get('MAIL_PORT')
-MAIL_USE_TLS = True
-MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
-MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
+MAIL_DEFAULT_SENDER = os.environ('MAIL_DEFAULT_SENDER')
+
+if os.environ.get('MAIL_SERVER'):
+    MAIL_SERVER = os.environ.get('MAIL_SERVER')
+
+if os.environ.get('MAIL_PORT'):
+    MAIL_PORT = os.environ.get('MAIL_PORT')
+
+if os.environ.get('MAIL_USE_TLS'):
+    MAIL_USE_TLS = os.environ.get('MAIL_USE_TLS')
+
+if os.environ.get('MAIL_USERNAME'):
+    MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
+
+if os.environ.get('MAIL_PASSWORD'):
+    MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')


### PR DESCRIPTION
Only `MAIL_DEFAULT_SENDER` is required.

This change is required because there are environments where all the defaults work fine (like ours) and `os.environ.get()` sets the value of the variables to `None` if the environment variable is not present and that causes issues with `Flask-Mail` and `smtplib`.

**Testing instructions**:
* This can be tested in production only the `MAIL_DEFAULT_SENDER` environment variable is set.