### PR TITLE
[BB-1992] Multiple improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ pytest --cov=pr_watcher_notifier
 ```
 
 * Configure the environment variables used in the `settings.py` file.
-* Setup the watch configuration YAML file and configure the `WATCH_CONFIG_FILE` environment variable to point to it. The format is documented in `settings.py`.
+* Setup the watch configuration YAML file and configure the `WATCH_CONFIG_FILE` environment variable to point to it. The file format is documented in `watch_config.yml.sample`.
 * Set the `FLASK_APP` environment variable to point to the `run.py` file.
 * Set the `FLASK_DEBUG` environment variable to `1` and run the development server.
 

--- a/pr_watcher_notifier/github_api.py
+++ b/pr_watcher_notifier/github_api.py
@@ -3,7 +3,6 @@ Utility functions for interacting with the GitHub API.
 """
 import hashlib
 import hmac
-from fnmatch import fnmatch
 
 from flask import current_app
 from github import Github
@@ -58,44 +57,3 @@ def get_target_branch(pr):
     Return the target branch name of a pull request.
     """
     return pr.base.ref
-
-
-def should_send_notification(data):
-    """
-    Return whether the notification should be sent for the given request data or not.
-    """
-    action = data['action']
-    notify = False
-    matching_modified_files = []
-
-    if action in ('opened', 'closed', 'synchronize', 'reopened'):
-        repo = data['repository']['full_name']
-        pr_number = data['number']
-        pr = get_pr(repo, pr_number)
-        matched = False
-        watch_config = current_app.config['WATCH_CONFIG']
-        for modified_file in pr.get_files():
-            config = watch_config.get(repo)
-            if config:
-                for pattern in config['patterns']:
-                    if fnmatch(modified_file.filename, pattern):
-                        matched = True
-                        matching_modified_files.append(modified_file.filename)
-                if matched:
-                    break
-        if matched:
-            notify = True
-
-            # To avoid duplicate notifications for the same PR when its source branch is updated,
-            # check if the modifications to the watched patterns are first added by the changes
-            # in the update. This can be done by comparing the previous HEAD of the PR branch against
-            # the target branch and verifying that no files matching the patterns were modified.
-            if action == 'synchronize':
-                target = get_target_branch(pr)
-                previous_head = data['before']
-                for modified_file in get_comparison_file_names(repo, target, previous_head):
-                    for pattern in watch_config[repo]['patterns']:
-                        if fnmatch(modified_file, pattern):
-                            notify = False
-                            break
-    return notify, matching_modified_files

--- a/pr_watcher_notifier/github_api.py
+++ b/pr_watcher_notifier/github_api.py
@@ -49,7 +49,12 @@ def get_comparison_file_names(repo, base, head):
     """
     Return the file names of the file names modified in the given comparison.
     """
-    return get_file_names(get_client().get_repo(repo).compare(base, head).files)
+    files = []
+    try:
+        files = get_client().get_repo(repo).compare(base, head).files
+    except Exception:
+        current_app.logger.error('Failed to retrieve the files changed in the most recent update to the PR')
+    return get_file_names(files)
 
 
 def get_target_branch(pr):

--- a/pr_watcher_notifier/notification.py
+++ b/pr_watcher_notifier/notification.py
@@ -2,7 +2,7 @@
 Utility functions for sending notifications.
 """
 
-from flask import current_app, render_template
+from flask import render_template
 from flask_mail import Message
 
 from . import mail
@@ -28,7 +28,7 @@ def send_notifications(data):
     """
     pr_data = data['pull_request']
     repo = data['repository']['full_name']
-    watch_config = current_app.config['WATCH_CONFIG'][repo]
+    watch_config = data['watch_config']
     context = {
         'repo': repo,
         'number': data['number'],

--- a/pr_watcher_notifier/notification.py
+++ b/pr_watcher_notifier/notification.py
@@ -13,7 +13,7 @@ def send_email(context):
     Send the notification email.
     """
     subject = context['subject'].format(**context)
-    body = render_template('email_body.txt', **context)
+    body = render_template(context['body'], **context)
     msg = Message(
         subject,
         recipients=context['to'],
@@ -38,6 +38,7 @@ def send_notifications(data):
         'creator': pr_data['user']['login'],
         'to': watch_config['recipients'],
         'subject': watch_config['subject'],
+        'body': watch_config['body'] if 'body' in watch_config else 'email_body.txt',
         'pr_url': pr_data['_links']['html']['href'],
         'modified_files': data['modified_files'],
     }

--- a/pr_watcher_notifier/test_views.py
+++ b/pr_watcher_notifier/test_views.py
@@ -98,6 +98,26 @@ def test_pr_action_ignored(post, mocker):
     mocked_send_notifications.assert_not_called()
 
 
+def test_notification_not_sent_when_unable_to_retrieve_pr_details(post, mocker):
+    """
+    Test when unable to retrieve the PR details, for example due to not having access to the private repository
+    of the PR or when there are issues with the GitHub API.
+    """
+    mocker.patch(
+        'pr_watcher_notifier.views.get_pr',
+        side_effect=Exception()
+    )
+    response = post(json={
+        'repository': {
+            'full_name': 'a/b',
+            'private': False,
+        },
+        'number': 1,
+        'action': 'opened',
+    })
+    assert response.status_code == 200
+
+
 def test_no_files_matching_condition(post, mocker):
     """
     Test if no files in the opened PR match the watch pattern.

--- a/pr_watcher_notifier/test_views.py
+++ b/pr_watcher_notifier/test_views.py
@@ -3,7 +3,12 @@ Unit tests for the application.
 """
 from unittest.mock import MagicMock
 
+from .views import get_repo_watch_config
+
+
 URL = '/pull-requests'
+
+REPO_CONFIG1 = {'patterns': ['documents/*', ], 'recipients': 'nobody@example.com'}
 
 
 def get_dummy_pr_with_list_of_files(count):
@@ -84,7 +89,7 @@ def test_pr_action_ignored(post, mocker):
     """
     mocker.patch(
         'pr_watcher_notifier.views.get_request_json',
-        return_value={'number': 1, 'repository': {'full_name': 'a/b'}, 'action': 'edited'}
+        return_value={'number': 1, 'repository': {'full_name': 'a/b', 'private': False}, 'action': 'edited'}
     )
     mocked_send_notifications = mocker.patch('pr_watcher_notifier.notification.send_notifications')
 
@@ -99,10 +104,10 @@ def test_no_files_matching_condition(post, mocker):
     """
     mocker.patch(
         'pr_watcher_notifier.views.get_request_json',
-        return_value={'number': 1, 'repository': {'full_name': 'a/b'}, 'action': 'opened'}
+        return_value={'number': 1, 'repository': {'full_name': 'a/b', 'private': False}, 'action': 'opened'}
     )
     dummy_pr_object = get_dummy_pr_with_list_of_files(0)
-    mocker.patch('pr_watcher_notifier.github_api.get_pr', return_value=dummy_pr_object)
+    mocker.patch('pr_watcher_notifier.views.get_pr', return_value=dummy_pr_object)
     response = post(json={'a': '1'})
     assert response.status_code == 200
     mocked_send_notifications = mocker.patch('pr_watcher_notifier.notification.send_notifications')
@@ -117,11 +122,11 @@ def test_files_matching_condition(post, mocker):
     """
     mocker.patch(
         'pr_watcher_notifier.views.get_request_json',
-        return_value={'number': 1, 'repository': {'full_name': 'a/b'}, 'action': 'opened'}
+        return_value={'number': 1, 'repository': {'full_name': 'a/b', 'private': False}, 'action': 'opened'}
     )
     dummy_pr_object = get_dummy_pr_with_list_of_files(2)
-    mocker.patch('pr_watcher_notifier.github_api.fnmatch', return_value=True)
-    mocker.patch('pr_watcher_notifier.github_api.get_pr', return_value=dummy_pr_object)
+    mocker.patch('pr_watcher_notifier.views.fnmatch', return_value=True)
+    mocker.patch('pr_watcher_notifier.views.get_pr', return_value=dummy_pr_object)
     mocked_send_notifications = mocker.patch('pr_watcher_notifier.views.send_notifications')
     response = post(json={'a': 1})
     assert response.status_code == 201
@@ -135,13 +140,17 @@ def test_pr_synchronized_but_already_notified(post, mocker):
     """
     mocker.patch(
         'pr_watcher_notifier.views.get_request_json',
-        return_value={'number': 1, 'repository': {'full_name': 'a/b'}, 'action': 'synchronize', 'before': '123'}
+        return_value={
+            'number': 1,
+            'repository': {'full_name': 'a/b', 'private': False},
+            'action': 'synchronize', 'before': '123'
+        }
     )
     dummy_pr_object = get_dummy_pr_with_list_of_files(2)
-    mocker.patch('pr_watcher_notifier.github_api.fnmatch', return_value=True)
-    mocker.patch('pr_watcher_notifier.github_api.get_pr', return_value=dummy_pr_object)
-    mocker.patch('pr_watcher_notifier.github_api.get_target_branch', return_value='master')
-    mocker.patch('pr_watcher_notifier.github_api.get_comparison_file_names', return_value=['a', 'b', 'c'])
+    mocker.patch('pr_watcher_notifier.views.fnmatch', return_value=True)
+    mocker.patch('pr_watcher_notifier.views.get_pr', return_value=dummy_pr_object)
+    mocker.patch('pr_watcher_notifier.views.get_target_branch', return_value='master')
+    mocker.patch('pr_watcher_notifier.views.get_comparison_file_names', return_value=['a', 'b', 'c'])
     mocked_send_notifications = mocker.patch('pr_watcher_notifier.views.send_notifications')
     response = post(json={'a': 1})
     assert response.status_code == 200
@@ -155,13 +164,142 @@ def test_pr_synchronized_but_not_already_notified(post, mocker):
     """
     mocker.patch(
         'pr_watcher_notifier.views.get_request_json',
-        return_value={'number': 1, 'repository': {'full_name': 'a/b'}, 'action': 'synchronize', 'before': '123'}
+        return_value={
+            'number': 1,
+            'repository': {'full_name': 'a/b', 'private': False},
+            'action': 'synchronize',
+            'before': '123'
+        }
     )
     dummy_pr_object = get_dummy_pr_with_list_of_files(2)
-    mocker.patch('pr_watcher_notifier.github_api.fnmatch', side_effect=[True, False, False])
-    mocker.patch('pr_watcher_notifier.github_api.get_pr', return_value=dummy_pr_object)
-    mocker.patch('pr_watcher_notifier.github_api.get_target_branch', return_value='master')
-    mocker.patch('pr_watcher_notifier.github_api.get_comparison_file_names', return_value=['a', 'b'])
+
+    mocker.patch('pr_watcher_notifier.views.get_repo_watch_config', return_value=(REPO_CONFIG1, False))
+    mocker.patch('pr_watcher_notifier.views.fnmatch', side_effect=[True, False, False])
+    mocker.patch('pr_watcher_notifier.views.get_pr', return_value=dummy_pr_object)
+    mocker.patch('pr_watcher_notifier.views.get_target_branch', return_value='master')
+    mocker.patch('pr_watcher_notifier.views.get_comparison_file_names', return_value=['a', 'b'])
+    mocked_send_notifications = mocker.patch('pr_watcher_notifier.views.send_notifications')
+    response = post(json={'a': 1})
+    assert response.status_code == 201
+    mocked_send_notifications.assert_called_once()
+
+
+def test_get_repo_watch_config_when_a_matching_org_wildcard_pattern_is_present():
+    """
+    Test the get_repo_watch_config function when a matching wildcard pattern is present
+    """
+    repo_config, wildcard_match = get_repo_watch_config(
+        {
+            'a/*': {
+                'patterns': ['documents/*', ],
+                'recipients': 'nobody@example.com',
+            }
+        },
+        'a/abcd'
+    )
+    assert repo_config
+    assert wildcard_match
+
+
+def test_get_repo_watch_config_when_an_exact_match_and_a_matching_org_wildcard_pattern_present():
+    """
+    Test the get_repo_watch_config function when a wildcard pattern and an exact match are present
+    """
+    repo_config, wildcard_match = get_repo_watch_config(
+        {
+            'a/*': {
+                'patterns': ['documents/*', ],
+                'recipients': 'nobody@example.com',
+            },
+            'a/abcd': {
+                'patterns': ['documents/*', ],
+                'recipients': 'specific@example.com',
+            }
+        },
+        'a/abcd'
+    )
+    assert repo_config
+    assert repo_config['recipients'] == 'specific@example.com'
+    assert wildcard_match is False
+
+
+def test_notifications_not_sent_for_private_repo_with_only_a_matching_org_wildcard_pattern(post, mocker):
+    """
+    Test and verify that notifications are not sent by default for private repositories with a matching
+    organization wildcard pattern in configuration
+    """
+    mocker.patch(
+        'pr_watcher_notifier.views.get_request_json',
+        return_value={
+            'number': 1,
+            'repository': {'full_name': 'b/c', 'private': True},
+            'action': 'synchronize',
+            'before': '123'
+        }
+    )
+    dummy_pr_object = get_dummy_pr_with_list_of_files(2)
+    wildcard_match = True
+
+    mocker.patch('pr_watcher_notifier.views.get_repo_watch_config', return_value=(REPO_CONFIG1, wildcard_match))
+    mocker.patch('pr_watcher_notifier.views.fnmatch', side_effect=[True, False, False])
+    mocker.patch('pr_watcher_notifier.views.get_pr', return_value=dummy_pr_object)
+    mocker.patch('pr_watcher_notifier.views.get_target_branch', return_value='master')
+    mocker.patch('pr_watcher_notifier.views.get_comparison_file_names', return_value=['a', 'b'])
+    mocked_send_notifications = mocker.patch('pr_watcher_notifier.views.send_notifications')
+    response = post(json={'a': 1})
+    assert response.status_code == 200
+    mocked_send_notifications.assert_not_called()
+
+
+def test_notifications_sent_for_private_repo_with_an_exact_match(post, mocker):
+    """
+    Test and verify that notifications are sent for private repositories with an exactly matching
+    repo name in the watch configuration
+    """
+    mocker.patch(
+        'pr_watcher_notifier.views.get_request_json',
+        return_value={
+            'number': 1,
+            'repository': {'full_name': 'a/b', 'private': True},
+            'action': 'synchronize',
+            'before': '123'
+        }
+    )
+    wildcard_match = False
+    dummy_pr_object = get_dummy_pr_with_list_of_files(2)
+    mocker.patch('pr_watcher_notifier.views.get_repo_watch_config', return_value=(REPO_CONFIG1, wildcard_match))
+    mocker.patch('pr_watcher_notifier.views.fnmatch', side_effect=[True, False, False])
+    mocker.patch('pr_watcher_notifier.views.get_pr', return_value=dummy_pr_object)
+    mocker.patch('pr_watcher_notifier.views.get_target_branch', return_value='master')
+    mocker.patch('pr_watcher_notifier.views.get_comparison_file_names', return_value=['a', 'b'])
+    mocked_send_notifications = mocker.patch('pr_watcher_notifier.views.send_notifications')
+    response = post(json={'a': 1})
+    assert response.status_code == 201
+    mocked_send_notifications.assert_called_once()
+
+
+def test_notifications_sent_for_private_repo_with_matching_org_wildcard_pattern_when_enabled_explicitly(post, mocker):
+    """
+    Test and verify that notifications are sent for private repositories with an exactly matching
+    repo name in the watch configuration
+    """
+    mocker.patch(
+        'pr_watcher_notifier.views.get_request_json',
+        return_value={
+            'number': 1,
+            'repository': {'full_name': 'b/c', 'private': True},
+            'action': 'synchronize',
+            'before': '123'
+        }
+    )
+    dummy_pr_object = get_dummy_pr_with_list_of_files(2)
+    wildcard_match = True
+    repo_config = {'patterns': ['documents/*', ], 'recipients': 'nobody@example.com', 'notify_for_private_repos': True}
+    mocker.patch('pr_watcher_notifier.views.get_repo_watch_config', return_value=(repo_config, wildcard_match))
+    mocker.patch('pr_watcher_notifier.views.fnmatch', side_effect=[True, False, False])
+    mocker.patch('pr_watcher_notifier.views.get_pr', return_value=dummy_pr_object)
+    mocker.patch('pr_watcher_notifier.views.get_target_branch', return_value='master')
+    mocker.patch('pr_watcher_notifier.views.get_comparison_file_names', return_value=['a', 'b'])
     mocked_send_notifications = mocker.patch('pr_watcher_notifier.views.send_notifications')
     response = post(json={'a': 1})
     assert response.status_code == 201

--- a/pr_watcher_notifier/views.py
+++ b/pr_watcher_notifier/views.py
@@ -1,9 +1,12 @@
 """
 views for the application.
 """
+
+from fnmatch import fnmatch
+
 from flask import abort, request, current_app, Blueprint
 
-from .github_api import is_signature_valid, should_send_notification
+from .github_api import get_comparison_file_names, get_target_branch, get_pr, is_signature_valid
 from .notification import send_notifications
 
 APP = Blueprint('app.views', __name__, template_folder='templates')
@@ -18,6 +21,65 @@ def get_request_json(req):
         current_app.logger.error('Invalid JSON in the request body')
         abort(400)
     return data
+
+
+def get_repo_watch_config(watch_config, repo):
+    """
+    Return the watch configuration for a given repository.
+    """
+    repo_config = {}
+    wildcard_match = False
+    for watched_repo_name, config in watch_config.items():
+        if fnmatch(repo, watched_repo_name):
+            repo_config = config
+            if '/*' not in watched_repo_name:
+                wildcard_match = False
+                break
+            wildcard_match = True
+    return repo_config, wildcard_match
+
+
+def should_send_notification(data):
+    """
+    Return whether the notification should be sent for the given request data or not.
+    """
+    action = data['action']
+    notify = False
+    matching_modified_files = []
+    if action in ('opened', 'closed', 'synchronize', 'reopened'):
+        repo = data['repository']['full_name']
+        is_private = data['repository']['private']
+        pr_number = data['number']
+        pr = get_pr(repo, pr_number)
+        matched = False
+        watch_config = current_app.config['WATCH_CONFIG']
+        config, wildcard_match = get_repo_watch_config(watch_config, repo)
+        if is_private and wildcard_match and not config.get('notify_for_private_repos', False):
+            return False, []
+        if config:
+            for modified_file in pr.get_files():
+                for pattern in config['patterns']:
+                    if fnmatch(modified_file.filename, pattern):
+                        matched = True
+                        matching_modified_files.append(modified_file.filename)
+                if matched:
+                    break
+        if matched:
+            notify = True
+
+            # To avoid duplicate notifications for the same PR when its source branch is updated,
+            # check if the modifications to the watched patterns are first added by the changes
+            # in the update. This can be done by comparing the previous HEAD of the PR branch against
+            # the target branch and verifying that no files matching the patterns were modified.
+            if action == 'synchronize':
+                target = get_target_branch(pr)
+                previous_head = data['before']
+                for modified_file in get_comparison_file_names(repo, target, previous_head):
+                    for pattern in config['patterns']:
+                        if fnmatch(modified_file, pattern):
+                            notify = False
+                            break
+    return notify, matching_modified_files
 
 
 @APP.route('/pull-requests', methods=['POST', ])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-pytest==4.6.3
-pytest-cov==2.7.1
-pytest-mock==1.10.4
+pytest==5.3.2
+pytest-cov==2.8.1
+pytest-mock==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.0.3
+Flask==1.1.1
 Flask-Mail==0.9.1
-PyGithub==1.43.7
-PyYAML==5.1.1
+PyGithub==1.45
+PyYAML==5.2

--- a/settings.py
+++ b/settings.py
@@ -5,6 +5,7 @@ import os
 
 import yaml
 
+
 def get_watch_config():
     """
     Load the watch configuration from the YAML file specified in
@@ -17,18 +18,6 @@ def get_watch_config():
 
 GITHUB_WEBHOOK_SECRET = os.environ['GITHUB_WEBHOOK_SECRET']
 GITHUB_ACCESS_TOKEN = os.environ['GITHUB_ACCESS_TOKEN']
-
-# Expected format of values in the YAML configuration file.
-# Repeat the same block for configuring multiple repositories.
-#
-# ---
-# <repo owner>/<repo name>:
-#   patterns:
-#     - "pattern1"
-#     - "pattern2"
-#   recipients:
-#     - "nobody@example.com"
-#   subject: "Subject text, see code for available format strings"
 
 WATCH_CONFIG = get_watch_config()
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -5,5 +5,14 @@ WATCH_CONFIG = {
     'a/b': {
         'patterns': ['documents/*', ],
         'recipients': 'nobody@example.com',
+    },
+    'b/*': {
+        'patterns': ['documents/*', ],
+        'recipients': 'nobody@example.com',
+    },
+    'c/d': {
+        'patterns': ['documents/*', ],
+        'recipients': 'nobody@example.com',
+        'notify_for_private_repos': True,
     }
 }

--- a/watch_config.yml.sample
+++ b/watch_config.yml.sample
@@ -1,0 +1,25 @@
+---
+a/b:
+  patterns: # Patterns can be specified using unix shell-style wildcards as documented at https://docs.python.org/3/library/fnmatch.html
+    - documents/*
+  recipients:
+    - nobody@example.com
+  subject: "PR Watcher notifier: watched change in {repo}"
+b/*:  # Wildcards like this, ending with /* can be used watch all repositories under a GitHub organization
+  patterns:
+    - docs/*
+    - tests/*
+    - common/lib/mylibrary/__init__.py
+  recipients:
+    - nobody@example.com
+  subject: "PR Watcher notifier: watched change in {repo} under 'b' organization"
+  body: /path/to/body/template/file/under/the/pr_watcher_notifier/templates/dir  # Optional. Path to the jinja2 template file to use for rendering the email body. Defaults to the provided 'pr_watcher_notifier/templates/email_body.txt' template.
+c/*:
+  patterns:
+    - documents/*
+  recipients:
+    - nobody@example.com
+  subject: "PR Watcher notifier: watched change in {repo} under 'c' organization"
+  # This is only used for wildcard repository patterns corresponding to GitHub organizations
+  # and defaults to False
+  notify_for_private_repos: True


### PR DESCRIPTION
Adds the following changes:
* Allow specifying all the repositories of a user or organization using a wildcard like `<entity>/*` in the app's configuration file.
* Allow providing a custom body template for each repo.
* Ignore notifications from private repositories unless explicitly allowed.
* Update the versions of the dependency libraries.

**Testing instructions**:
* Set up the development environment as documented in the README.
* Add some watch configurations in the configuration file. Include wildcards as well.
* Set up the webhook on the watched repositories. Use a tool like ngrok to get a public endpoint for the local app.
* Create/update PRs matching the configured patterns in the watched repositories.
* When the repo of a PR matches an exact repo name and also a wildcard pattern, verify that only the exact match is always used.
* Test and verify that notifications are not sent for private repositories matched by a wildcard pattern, unless explicitly allowed using the `notify_for_private_repos` configuration parameter.
* Test the other general behaviour of the app and verify that it works okay in unexpected or corner cases. For example, test the behaviour with a GitHub access token that doesn't have access to the private repos.