### PR TITLE
Add support for deploying to heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: ./do_pre_release_steps.sh && gunicorn run:app

--- a/README.md
+++ b/README.md
@@ -59,3 +59,12 @@ command respectively.
 ```bash
 $ flask run -h 0.0.0.0 -p 8000
 ```
+
+Deploying to Heroku
+===================
+
+An example `Procfile` which deploys this app to Heroku using gunicorn is provided. In addition to the `web` process that runs the app,
+it also defines a `release` process that runs the `do_pre_release_steps.sh` script. The script downloads the watch configuration
+file named `config.yml` from an external git repository specified in the `CUSTOM_CONFIG_REPO` environment variable to the location
+specified in the `WATCH_CONFIG_FILE` environment variable. If the repository also contains a `templates` sub-directory containing
+the custom email templates, those are copied to the app templates directory and can be used in the watch configuration file.

--- a/do_pre_release_steps.sh
+++ b/do_pre_release_steps.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eu
+app_root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $app_root_dir
+rm -rf $app_root_dir/custom_config
+git clone $CUSTOM_CONFIG_REPO $app_root_dir/custom_config
+cp $app_root_dir/custom_config/config.yml $WATCH_CONFIG_FILE
+CUSTOM_TEMPLATES_DIR="$app_root_dir/custom_config/templates"
+if [ -d "$CUSTOM_TEMPLATES_DIR" ]; then
+    cp $CUSTOM_TEMPLATES_DIR/* $app_root_dir/pr_watcher_notifier/templates/.
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==1.1.1
 Flask-Mail==0.9.1
 PyGithub==1.45
 PyYAML==5.2
+gunicorn==20.0.4


### PR DESCRIPTION
This PR adds a `Procfile` with a pre-deploy script to download configuration files from an external source and runs the app using gunicorn.