### PR TITLE
Make all PR data available to templates

### DIFF
--- a/pr_watcher_notifier/notification.py
+++ b/pr_watcher_notifier/notification.py
@@ -33,11 +33,18 @@ def send_notifications(data):
     pr_data = data['pull_request']
     repo = data['repository']['full_name']
     watch_config = data['watch_config']
+
+    action = data['action']
+    if action == 'synchronize':
+        action = 'updated'
+    elif action == 'closed' and pr_data['merged'] is True:
+        action = 'merged'
+
     context = {
         'repo': repo,
         'number': data['number'],
         'patterns': ", ".join(watch_config['patterns']),
-        'action': data['action'] if data['action'] != 'synchronize' else 'updated',
+        'action': action,
         'merged': pr_data['merged'],
         'creator': pr_data['user']['login'],
         'to': watch_config['recipients'],

--- a/pr_watcher_notifier/notification.py
+++ b/pr_watcher_notifier/notification.py
@@ -12,6 +12,7 @@ def send_email(context):
     """
     Send the notification email.
     """
+    current_app.logger.debug('Sending email with context: {}'.format(context))
     subject = context['subject'].format(**context)
     body = render_template(context['body'], **context)
     msg = Message(
@@ -44,5 +45,6 @@ def send_notifications(data):
         'body': watch_config['body'] if 'body' in watch_config else 'email_body.txt',
         'pr_url': pr_data['_links']['html']['href'],
         'modified_files': data['modified_files'],
+        'pr': pr_data,
     }
     send_email(context)


### PR DESCRIPTION
This way I can add info like `{{ pr.title }}`.

This also adjusts "action" so that it reports "merged" instead of "closed" for merged pull requests.