### PR TITLE
Don't mock fnmatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ requirements: ## Install the Python development requirements\
 
 .PHONY: test
 test: ## Run the Python tests
-	pytest --cov=pr_watcher_notifier
+	pytest -rfe --cov=pr_watcher_notifier
 
 .PHONY: test.quality
 test.quality:

--- a/pr_watcher_notifier/conftest.py
+++ b/pr_watcher_notifier/conftest.py
@@ -17,12 +17,10 @@ class FakeFile:
         self.filename = name
 
 
-def get_dummy_pr_with_list_of_files(count=None, names=None):
+def get_dummy_pr_with_list_of_files(names):
     """
     Create a PR with a dummy list of files.
     """
-    if names is None:
-        names = ["file{}".format(n) for n in range(count)]
     dummy_pr_object = MagicMock()
     dummy_get_files = MagicMock(return_value=[FakeFile(n) for n in names])
     dummy_pr_object.get_files = dummy_get_files

--- a/pr_watcher_notifier/github_api.py
+++ b/pr_watcher_notifier/github_api.py
@@ -47,7 +47,7 @@ def get_file_names(files):
 
 def get_comparison_file_names(repo, base, head):
     """
-    Return the file names of the file names modified in the given comparison.
+    Return the file names of the files modified in the given comparison.
     """
     files = []
     try:


### PR DESCRIPTION
Use more explicit file names in tests, so we don't have to mock fnmatch.